### PR TITLE
Dev

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ CFLAGS = -Wall -Wextra -Iinclude -Isrc
 LIBS = -lcurl -ljson-c -lncurses
 SRC = src/main.c src/ui.c src/api.c src/utils.c
 OBJ = $(SRC:.c=.o)
-TARGET = anime-cli.exe
+TARGET = anime-cli
 
 all: $(TARGET)
 


### PR DESCRIPTION
This pull request includes changes to the `Makefile` to update the target executable name and add a new target for continuous integration (CI).

Updates to the `Makefile`:

* Changed the target executable name from `anime-cli.exe` to `anime-cli`.
* Added a new `dist` target to create a distribution package, including the executable, `README.md`, and `LICENSE` files, and compressing them into a tarball.